### PR TITLE
Repository/expense split

### DIFF
--- a/src/app/models/data_models.py
+++ b/src/app/models/data_models.py
@@ -1,17 +1,7 @@
 import datetime
 from uuid import uuid4
 
-from sqlalchemy import (
-    DECIMAL,
-    UUID,
-    Boolean,
-    Column,
-    DateTime,
-    Enum,
-    ForeignKey,
-    String,
-    Text,
-)
+from sqlalchemy import UUID, Boolean, Column, DateTime, Enum, ForeignKey, String, Text
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -62,7 +52,7 @@ class Expense(Base):
     __tablename__ = "expenses"
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     group_id = Column(UUID(as_uuid=True), ForeignKey("groups.id"), nullable=True)
-    total_amount = Column(DECIMAL, nullable=False)
+    total_amount = Column(float, nullable=False)
     description = Column(Text, nullable=True)
     expense_type = Column(
         Enum("GROUP", "NON-EXPENSE GROUP", name="expense_type_enum"), nullable=False
@@ -79,7 +69,7 @@ class ExpenseSplit(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     expense_id = Column(UUID(as_uuid=True), ForeignKey("expenses.id"), nullable=False)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    amount_owed = Column(DECIMAL, nullable=False)
+    amount_owed = Column(float, nullable=False)
     split_type = Column(
         Enum(
             "UNEQUALLY",
@@ -104,7 +94,7 @@ class Settlements(Base):
     )
     payer_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     payee_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    amount = Column(DECIMAL, nullable=False)
+    amount = Column(float, nullable=False)
     is_settled = Column(Boolean, default=False)
     created_at = Column(DateTime, default=datetime.datetime.now(datetime.UTC))
     expense_split = relationship("ExpenseSplit", back_populates="settlements")

--- a/src/app/repositories/expense_split_repository.py
+++ b/src/app/repositories/expense_split_repository.py
@@ -34,7 +34,6 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
         """
         Retrieve all ExpenseSplits matching the given filters.
 
-        :parameter id: UUID of the ExpenseSplit
         :parameter amount_owed: Amount owed in the ExpenseSplit
         :parameter split_type: Type of split
         :parameter user_id: UUID of the user

--- a/src/app/repositories/expense_split_repository.py
+++ b/src/app/repositories/expense_split_repository.py
@@ -6,6 +6,10 @@ from app.models.data_models import ExpenseSplit
 from app.repositories.base_repository import BaseRepository
 
 class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
+    """
+    Repository for managing ExpenseSplit entities.
+    Provides methods for CRUD operations and querying by various filters.
+    """
 
     def get(self, id: UUID) -> Optional[ExpenseSplit]:
         """
@@ -87,4 +91,3 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
         expense_split = self.get(id)
         if expense_split:
             self.session.delete(expense_split)
-            

--- a/src/app/repositories/expense_split_repository.py
+++ b/src/app/repositories/expense_split_repository.py
@@ -1,0 +1,89 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlalchemy.orm import Session
+from sqlalchemy import asc, desc
+from app.models.data_models import ExpenseSplit
+from app.repositories.base_repository import BaseRepository
+
+class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
+
+    def get(self, id: UUID) -> Optional[ExpenseSplit]:
+        """
+        Retrieve an ExpenseSplit by its ID.
+
+        :parameter id: UUID of the ExpenseSplit
+        :return: ExpenseSplit object or None if not found
+        """
+        return self.session.query(ExpenseSplit).filter_by(ExpenseSplit.id == id).first()
+
+    def get_all(self,
+                id: Optional[UUID] = None,
+                amount_owed: Optional[float] = None,
+                split_type: Optional[str] = None,
+                user_id: Optional[UUID] = None,
+                expense_id: Optional[UUID] = None,
+                sort_by: Optional[str] = None,
+                order: Optional[str] = "asc") -> List[ExpenseSplit]:
+        """
+        Retrieve all ExpenseSplits matching the given filters.
+
+        :parameter id: UUID of the ExpenseSplit
+        :parameter amount_owed: Amount owed in the ExpenseSplit
+        :parameter split_type: Type of split
+        :parameter user_id: UUID of the user
+        :parameter expense_id: UUID of the expense
+        :parameter sort_by: Field to sort by
+        :parameter order: Sort order ('asc' or 'desc')
+        :return: List of matching ExpenseSplit objects
+        """
+        query = self.session.query(ExpenseSplit)
+        
+        if id:
+            query = query.filter(ExpenseSplit.id == id)
+        if amount_owed:
+            query = query.filter(ExpenseSplit.amount_owed == amount_owed)
+        if split_type:
+            query = query.filter(ExpenseSplit.split_type == split_type)
+        if user_id:
+            query = query.filter(ExpenseSplit.user_id == user_id)
+        if expense_id:
+            query = query.filter(ExpenseSplit.expense_id == expense_id)
+        
+        if sort_by:
+            if order == "asc":
+                query = query.order_by(asc(getattr(ExpenseSplit, sort_by)))
+            else:
+                query = query.order_by(desc(getattr(ExpenseSplit, sort_by)))
+        
+        return query.all()
+
+    def add(self, **kwargs: object) -> None:
+        """
+        Add a new ExpenseSplit to the database.
+
+        :parameter kwargs: Fields and values for the new ExpenseSplit
+        """
+        expense_split = ExpenseSplit(**kwargs)
+        self.session.add(expense_split)
+
+    def update(self, id: UUID, **kwargs: object) -> None:
+        """
+        Update an existing ExpenseSplit.
+
+        :parameter id: UUID of the ExpenseSplit to update
+        :parameter kwargs: Fields and values to update
+        """
+        expense_split = self.get(id)
+        if expense_split:
+            for key, value in kwargs.items():
+                setattr(expense_split, key, value)
+
+    def delete(self, id: UUID) -> None:
+        """
+        Delete an ExpenseSplit from the database.
+
+        :parameter id: UUID of the ExpenseSplit to delete
+        """
+        expense_split = self.get(id)
+        if expense_split:
+            self.session.delete(expense_split)

--- a/src/app/repositories/expense_split_repository.py
+++ b/src/app/repositories/expense_split_repository.py
@@ -24,7 +24,6 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
 
     def get_all(
         self,
-        id: Optional[UUID] = None,
         amount_owed: Optional[float] = None,
         split_type: Optional[str] = None,
         user_id: Optional[UUID] = None,
@@ -45,9 +44,6 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
         :return: List of matching ExpenseSplit objects
         """
         query = self.session.query(ExpenseSplit)
-
-        if id:
-            query = query.filter(ExpenseSplit.id == id)
         if amount_owed:
             query = query.filter(ExpenseSplit.amount_owed == amount_owed)
         if split_type:

--- a/src/app/repositories/expense_split_repository.py
+++ b/src/app/repositories/expense_split_repository.py
@@ -87,3 +87,4 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
         expense_split = self.get(id)
         if expense_split:
             self.session.delete(expense_split)
+            

--- a/src/app/repositories/expense_split_repository.py
+++ b/src/app/repositories/expense_split_repository.py
@@ -1,9 +1,11 @@
 from typing import List, Optional
 from uuid import UUID
-from sqlalchemy.orm import Session
+
 from sqlalchemy import asc, desc
+
 from app.models.data_models import ExpenseSplit
 from app.repositories.base_repository import BaseRepository
+
 
 class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
     """
@@ -18,16 +20,18 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
         :parameter id: UUID of the ExpenseSplit
         :return: ExpenseSplit object or None if not found
         """
-        return self.session.query(ExpenseSplit).filter_by(ExpenseSplit.id == id).first()
+        return self.session.query(ExpenseSplit).filter(ExpenseSplit.id == id).first()
 
-    def get_all(self,
-                id: Optional[UUID] = None,
-                amount_owed: Optional[float] = None,
-                split_type: Optional[str] = None,
-                user_id: Optional[UUID] = None,
-                expense_id: Optional[UUID] = None,
-                sort_by: Optional[str] = None,
-                order: Optional[str] = "asc") -> List[ExpenseSplit]:
+    def get_all(
+        self,
+        id: Optional[UUID] = None,
+        amount_owed: Optional[float] = None,
+        split_type: Optional[str] = None,
+        user_id: Optional[UUID] = None,
+        expense_id: Optional[UUID] = None,
+        sort_by: Optional[str] = None,
+        order: Optional[str] = "asc",
+    ) -> List[ExpenseSplit]:
         """
         Retrieve all ExpenseSplits matching the given filters.
 
@@ -41,7 +45,7 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
         :return: List of matching ExpenseSplit objects
         """
         query = self.session.query(ExpenseSplit)
-        
+
         if id:
             query = query.filter(ExpenseSplit.id == id)
         if amount_owed:
@@ -52,13 +56,13 @@ class ExpenseSplitRepository(BaseRepository[ExpenseSplit]):
             query = query.filter(ExpenseSplit.user_id == user_id)
         if expense_id:
             query = query.filter(ExpenseSplit.expense_id == expense_id)
-        
+
         if sort_by:
             if order == "asc":
                 query = query.order_by(asc(getattr(ExpenseSplit, sort_by)))
             else:
                 query = query.order_by(desc(getattr(ExpenseSplit, sort_by)))
-        
+
         return query.all()
 
     def add(self, **kwargs: object) -> None:


### PR DESCRIPTION
This PR adds the **expense_split_repository**, which helps manage ExpenseSplit records in the database. It includes methods to create, read, update, and delete entries, along with filtering and sorting options.

Added get(id): Fetches an ExpenseSplit by its ID.
Added get_all(...): Supports filtering by id, amount_owed, split_type, user_id, and expense_id. Also allows sorting.
Added add(**kwargs): Creates a new ExpenseSplit entry.
Added update(id, **kwargs): Updates an existing record.
Added delete(id): Removes an ExpenseSplit from the database.

This makes it easier to handle ExpenseSplit data consistently and efficiently while ensuring we can filter and sort results based on different needs.