### PR TITLE
4.2-view_group_details: Add endpoint to view group details

### DIFF
--- a/src/app/routes/v1/group_management_routers.py
+++ b/src/app/routes/v1/group_management_routers.py
@@ -1,8 +1,24 @@
+from uuid import UUID
+
 from fastapi import APIRouter
+
+from src.app.schemas.group_schemas import GroupResponse
+from src.app.services.group_services import get_particular_group
+from src.app.services.unit_of_work import GroupUnitOfWork
 
 router = APIRouter(tags=["Group Management Routes"])
 
 
-@router.get("/groups/test")
-def testing():
-    return {"message": "Hello World from group!"}
+@router.get("/groups/{group_id}", response_model=GroupResponse)
+def view_particular_group(group_id: UUID):
+    """
+    Retrieve details of a specific group by its unique identifier.
+
+    Parameters:
+        group_id (UUID): The unique identifier of the group.
+
+    Returns:
+        GroupResponse: The response model containing the group's details.
+    """
+    unit_of_work = GroupUnitOfWork()
+    return get_particular_group(unit_of_work=unit_of_work, group_id=group_id)

--- a/src/app/schemas/group_schemas.py
+++ b/src/app/schemas/group_schemas.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import UUID4, BaseModel
+
+
+class TypeEnum(str, Enum):
+    trip = "trip"
+    home = "home"
+    other = "other"
+
+
+class GroupResponse(BaseModel):
+    id: UUID4
+    name: str
+    type: TypeEnum
+    created_by: UUID4
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/src/app/services/group_services.py
+++ b/src/app/services/group_services.py
@@ -1,0 +1,30 @@
+from uuid import UUID
+
+from fastapi import HTTPException
+
+from src.app.schemas.group_schemas import GroupResponse
+from src.app.services.unit_of_work import GroupUnitOfWork
+
+
+def get_particular_group(
+    unit_of_work: GroupUnitOfWork, group_id: UUID
+) -> GroupResponse:
+    """
+    Retrieve a particular group by its ID.
+
+    Parameters:
+        unit_of_work (GroupUnitOfWork): The unit of work used for database operations.
+        group_id (UUID): The ID of the group to retrieve.
+
+    Returns:
+        GroupResponse: The details of the group.
+
+    Raises:
+        HTTPException: If the group is not found.
+    """
+    with unit_of_work as uow:
+        group = uow.group.get(id=group_id)
+        if not group:
+            raise HTTPException(status_code=404, detail="Group not found")
+        group_response = GroupResponse.model_validate(group)
+    return group_response

--- a/src/app/services/unit_of_work.py
+++ b/src/app/services/unit_of_work.py
@@ -1,6 +1,7 @@
 from abc import ABC
 
 from src.app.config.database import get_db
+from src.app.repositories.group_repository import GroupRepository
 
 
 class BaseUnitOfWork(ABC):
@@ -48,3 +49,17 @@ class BaseUnitOfWork(ABC):
         Roll back the current transaction, reverting uncommitted changes.
         """
         self.session.rollback()
+
+
+class GroupUnitOfWork(BaseUnitOfWork):
+    """
+    A Unit of Work implementation for managing database transactions related to groups.
+    """
+
+    def __enter__(self):
+        """
+        Enter the runtime context, initializing a new database session and repositories.
+        """
+        super().__enter__()
+        self.group = GroupRepository(session=self.session)
+        return self


### PR DESCRIPTION
This PR introduces a new API endpoint to retrieve details of a specific group using its unique identifier(UUID).

- Implements GET /groups/{group_id} to retrieve details of a specific group.
- Returns group information like:
   - Group ID
   - Name
   - Type
   - Created By
   - Created At
- Uses GroupUnitOfWork for data retrieval and transaction management.