### PR TITLE
 Logout endpoint-User Management

### DIFF
--- a/src/app/auth/auth.py
+++ b/src/app/auth/auth.py
@@ -1,0 +1,116 @@
+from fastapi import HTTPException, Request
+from fastapi.security import HTTPBearer
+from jose import JWTError, jwt
+from redis import Redis
+
+from src.app.config.redis import settings
+from src.app.config.settings import app_config
+
+redis_client = Redis(
+    host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=0, decode_responses=True
+)
+
+
+class JWTBearer(HTTPBearer):
+    """
+    A custom security class that extends HTTPBearer to handle JWT authentication.
+
+    This class:
+    - Extracts the token from the request header.
+    - Verifies that the token follows the Bearer authentication scheme.
+    - Checks if the token is blacklisted (revoked) in Redis.
+    - Provides methods to verify and extract user details from the JWT token.
+    """
+
+    def __init__(self, auto_error: bool = True):
+        """
+        Initializes the JWTBearer class.
+
+        Args:
+            auto_error (bool, optional): Whether to automatically raise an exception
+                if authentication fails. Defaults to True.
+        """
+        super().__init__(auto_error=auto_error)
+
+    async def __call__(self, request: Request):
+        """
+        Extracts and validates the JWT token from the request.
+
+        Args:
+            request (Request): The incoming FastAPI request.
+
+        Returns:
+            str: The extracted and validated JWT token.
+
+        Raises:
+            HTTPException: If the authentication scheme is invalid.
+            HTTPException: If the token is revoked.
+            HTTPException: If no valid authorization credentials are found.
+        """
+        credentials = await super().__call__(request)
+        if credentials:
+            if credentials.scheme != "Bearer":
+                raise HTTPException(
+                    status_code=403, detail="Invalid authentication scheme."
+                )
+
+            token = credentials.credentials
+
+            if redis_client.get(f"blacklist:{token}"):
+                raise HTTPException(status_code=401, detail="Token has been revoked.")
+
+            return token
+        else:
+            raise HTTPException(status_code=403, detail="Invalid authorization code.")
+
+    def verify_jwt(self, token: str) -> dict:
+        """
+        Verifies and decodes the JWT token.
+
+        Args:
+            token (str): The JWT token to verify.
+
+        Returns:
+            dict: The decoded JWT payload.
+
+        Raises:
+            HTTPException: If the token is invalid or expired.
+            HTTPException: If the user_id is missing in the token.
+        """
+        try:
+            payload = jwt.decode(
+                token, app_config["SECRET_KEY"], algorithms=[app_config["ALGORITHM"]]
+            )
+            user_id = payload.get("user_id")
+            if not user_id:
+                raise HTTPException(
+                    status_code=401, detail="Invalid token: user_id not found"
+                )
+            return payload
+        except JWTError:
+            raise HTTPException(status_code=403, detail="Invalid or expired token.")
+
+    def get_user_id_from_token(self, token: str) -> str:
+        """
+        Extracts the user ID from the JWT token.
+
+        Args:
+            token (str): The JWT token.
+
+        Returns:
+            str: The user ID extracted from the token.
+
+        Raises:
+            HTTPException: If the token is invalid or expired.
+            HTTPException: If the user_id is missing from the token.
+        """
+        try:
+            payload = self.verify_jwt(token)
+            user_id = payload.get("user_id")
+            if not user_id:
+                raise HTTPException(
+                    status_code=401, detail="Invalid token: user_id not found"
+                )
+            return user_id
+        except JWTError:
+            raise HTTPException(status_code=401, detail="Invalid or expired token")

--- a/src/app/auth/auth.py
+++ b/src/app/auth/auth.py
@@ -3,8 +3,7 @@ from fastapi.security import HTTPBearer
 from jose import JWTError, jwt
 from redis import Redis
 
-from src.app.config.redis import settings
-from src.app.config.settings import app_config
+from src.app.config.settings import app_config, settings
 
 redis_client = Redis(
     host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=0, decode_responses=True

--- a/src/app/config/redis.py
+++ b/src/app/config/redis.py
@@ -1,0 +1,9 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    REDIS_HOST: str = "localhost"
+    REDIS_PORT: int = 6379
+
+
+settings = Settings()

--- a/src/app/config/redis.py
+++ b/src/app/config/redis.py
@@ -1,9 +1,0 @@
-from pydantic_settings import BaseSettings
-
-
-class Settings(BaseSettings):
-    REDIS_HOST: str = "localhost"
-    REDIS_PORT: int = 6379
-
-
-settings = Settings()

--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -1,6 +1,7 @@
 from os import path
 
 from dotenv.main import dotenv_values
+from pydantic_settings import BaseSettings
 
 
 def get_settings():
@@ -19,3 +20,15 @@ def get_settings():
 
 
 app_config = get_settings()
+
+
+class Settings(BaseSettings):
+    REDIS_HOST: str
+    REDIS_PORT: int
+
+    class Config:
+        env_file = ".env"
+        extra = "allow"
+
+
+settings = Settings()

--- a/src/app/routes/v1/user_management_routers.py
+++ b/src/app/routes/v1/user_management_routers.py
@@ -3,7 +3,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from redis import Redis
 
 from src.app.auth.auth import JWTBearer
-from src.app.config.redis import settings
+from src.app.config.settings import settings
 from src.app.schemas.user_schemas import LoginInput, LoginOutput
 from src.app.services.unit_of_work import UserUnitOfWork
 from src.app.services.user_service import UserService

--- a/src/app/routes/v1/user_management_routers.py
+++ b/src/app/routes/v1/user_management_routers.py
@@ -1,8 +1,57 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from redis import Redis
+
+from src.app.auth.auth import JWTBearer
+from src.app.config.redis import settings
+from src.app.schemas.user_schemas import LoginInput, LoginOutput
+from src.app.services.unit_of_work import UserUnitOfWork
+from src.app.services.user_service import UserService
 
 router = APIRouter(tags=["User Management Routes"])
+redis_client = Redis(
+    host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=0, decode_responses=True
+)
 
 
-@router.get("/register/test")
-def testing():
-    return {"message": "Hello World from settle-up!"}
+def get_uow() -> UserUnitOfWork:
+    """
+    Dependency function to get a Unit of Work instance.
+
+    Returns:
+        UserUnitOfWork: An instance of the unit of work for database transactions.
+    """
+    return UserUnitOfWork()
+
+
+@router.post("/login", response_model=LoginOutput)
+def login(login_user: LoginInput, uow: UserUnitOfWork = Depends(get_uow)):
+    """
+    Authenticates a user and returns an access token.
+
+    Args:
+        login_user (LoginInput): The login credentials (email and password).
+        uow (UserUnitOfWork, optional): The unit of work dependency for database transactions. Defaults to using `get_uow()`.
+
+    Returns:
+        LoginOutput: A response containing the JWT access token and token type.
+    """
+    return UserService().login(login_user, uow)
+
+
+@router.post("/logout")
+def logout(token: str = Depends(JWTBearer())):
+    """
+    Logs out the user by blacklisting the provided JWT token.
+
+    This endpoint ensures that a logged-out token is stored in Redis, preventing
+    further use until it expires.
+
+    Args:
+        token (str): The JWT access token extracted from the request header
+                     using the `JWTBearer` dependency.
+
+    Returns:
+        dict: A message confirming successful logout."
+    """
+    return UserService.logout(token)

--- a/src/app/schemas/user_schemas.py
+++ b/src/app/schemas/user_schemas.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class UserBase(BaseModel):
+    """Common fields shared by multiple schemas."""
+
+    name: str
+    email: EmailStr
+    phone: Optional[str] = Field(
+        None, min_length=10, max_length=10, pattern=r"^\d{10}$"
+    )
+    profile_picture_url: Optional[str] = None
+
+
+class UserCreate(UserBase):
+    """Schema for user registration."""
+
+    password: str
+
+
+class UserResponse(BaseModel):
+    """Schema for user details response."""
+
+    name: str
+    email: EmailStr
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating user details"""
+
+    name: Optional[str] = None
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = Field(
+        None, min_length=10, max_length=10, pattern=r"^\d{10}$"
+    )
+    profile_picture_url: Optional[str] = None
+
+
+class LoginInput(BaseModel):
+    """Schema for user login."""
+
+    email: EmailStr
+    password: str
+
+
+class LoginOutput(BaseModel):
+    """Schema for returning access tokens."""
+
+    token_type: str
+    access_token: str

--- a/src/app/services/unit_of_work.py
+++ b/src/app/services/unit_of_work.py
@@ -1,6 +1,7 @@
 from abc import ABC
 
 from src.app.config.database import get_db
+from src.app.repositories.user_repository import UserRepository
 
 
 class BaseUnitOfWork(ABC):
@@ -48,3 +49,20 @@ class BaseUnitOfWork(ABC):
         Roll back the current transaction, reverting uncommitted changes.
         """
         self.session.rollback()
+
+
+class UserUnitOfWork(BaseUnitOfWork):
+    """
+    A Unit of Work implementation for managing user-related database transactions.
+    This class extends `UnitOfWorkBase` and provides a `UserRepository` instance
+    """
+
+    def __enter__(self):
+        """
+        Initializes the database session and sets up the user repository.
+        Returns:
+            UserUnitOfWork: The Unit of Work instance with an active session and user repository.
+        """
+        super().__enter__()
+        self.user = UserRepository(session=self.session)
+        return self

--- a/src/app/services/user_service.py
+++ b/src/app/services/user_service.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from uuid import UUID
 
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
@@ -79,10 +78,7 @@ class UserService:
         expire = datetime.utcnow() + timedelta(minutes=expire_minutes)
         to_encode.update({"exp": expire})
 
-        if isinstance(data.get("user_id"), UUID):
-            to_encode["user_id"] = str(data["user_id"])
-        else:
-            to_encode["user_id"] = data["user_id"]
+        to_encode["user_id"] = data["user_id"]
 
         return jwt.encode(
             to_encode, app_config["SECRET_KEY"], algorithm=app_config["ALGORITHM"]

--- a/src/app/services/user_service.py
+++ b/src/app/services/user_service.py
@@ -6,8 +6,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 from redis import Redis
 
-from src.app.config.redis import settings
-from src.app.config.settings import app_config
+from src.app.config.settings import app_config, settings
 from src.app.repositories.user_repository import UserRepository
 from src.app.schemas.user_schemas import LoginInput, LoginOutput, UserCreate
 from src.app.services.unit_of_work import UserUnitOfWork

--- a/src/app/services/user_service.py
+++ b/src/app/services/user_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -111,9 +111,9 @@ class UserService:
             )
             exp_timestamp = payload.get("exp")
             if exp_timestamp:
-                expiry_time = (
-                    datetime.utcfromtimestamp(exp_timestamp) - datetime.utcnow()
-                )
+                expiry_time = datetime.fromtimestamp(
+                    exp_timestamp, tz=timezone.utc
+                ) - datetime.now(timezone.utc)
                 redis_client.setex(
                     f"blacklist:{token}", int(expiry_time.total_seconds()), "revoked"
                 )

--- a/src/app/services/user_service.py
+++ b/src/app/services/user_service.py
@@ -1,0 +1,122 @@
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from redis import Redis
+
+from src.app.config.redis import settings
+from src.app.config.settings import app_config
+from src.app.repositories.user_repository import UserRepository
+from src.app.schemas.user_schemas import LoginInput, LoginOutput, UserCreate
+from src.app.services.unit_of_work import UserUnitOfWork
+
+redis_client = Redis(
+    host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=0, decode_responses=True
+)
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class UserService:
+    """
+    Service class for user authentication and registration.
+    """
+
+    @staticmethod
+    def login(user: LoginInput, uow: UserUnitOfWork) -> LoginOutput:
+        """
+        Authenticates a user and generates a JWT access token.
+
+        Args:
+            user (LoginInput): The login credentials (email and password).
+            uow (UserUnitOfWork): The unit of work for managing database transactions.
+
+        Returns:
+            LoginOutput: A response containing the JWT access token and token type.
+
+        Raises:
+            HTTPException: 400 Bad Request if authentication fails due to incorrect credentials.
+        """
+        with uow:
+            user_repo = UserRepository(uow.session)
+            db_user = user_repo.get(email=user.email)
+            if not db_user or not UserService.verify_password(
+                user.password, db_user.password
+            ):
+                raise HTTPException(status_code=400, detail="Invalid email or password")
+            access_token = UserService.create_access_token({"user_id": str(db_user.id)})
+            return LoginOutput(access_token=access_token, token_type="bearer")
+
+    @staticmethod
+    def verify_password(plain_password: str, hashed_password: str):
+        """
+        Verifies a plaintext password against its hashed version.
+
+        Args:
+            plain_password (str): The plaintext password entered by the user.
+            hashed_password (str): The hashed password stored in the database.
+
+        Returns:
+            bool: True if the passwords match, False otherwise.
+        """
+        return pwd_context.verify(plain_password, hashed_password)
+
+    @staticmethod
+    def create_access_token(data: dict):
+        """
+        Generates a JWT access token with an expiration time.
+
+        Args:
+            data (dict): The payload data, typically containing `user_id`.
+
+        Returns:
+            str: A signed JWT token.
+        """
+        to_encode = data.copy()
+        expire_minutes = int(app_config["ACCESS_TOKEN_EXPIRE_MINUTES"])
+        expire = datetime.utcnow() + timedelta(minutes=expire_minutes)
+        to_encode.update({"exp": expire})
+
+        if isinstance(data.get("user_id"), UUID):
+            to_encode["user_id"] = str(data["user_id"])
+        else:
+            to_encode["user_id"] = data["user_id"]
+
+        return jwt.encode(
+            to_encode, app_config["SECRET_KEY"], algorithm=app_config["ALGORITHM"]
+        )
+
+    def logout(token: str):
+        """
+
+        Blacklists a JWT token by storing it in Redis until it expires.
+
+        This function ensures that a logged-out token cannot be reused by adding it to
+        Redis with an expiration time equal to its remaining lifetime.
+
+        Args:
+            token (str): The JWT access token that needs to be revoked.
+
+        Returns:
+            dict: A message indicating the logout was successful.
+
+        Raises:
+            HTTPException (401 Unauthorized): If the token is invalid or cannot be decoded.
+        """
+        try:
+            payload = jwt.decode(
+                token, app_config["SECRET_KEY"], algorithms=[app_config["ALGORITHM"]]
+            )
+            exp_timestamp = payload.get("exp")
+            if exp_timestamp:
+                expiry_time = (
+                    datetime.utcfromtimestamp(exp_timestamp) - datetime.utcnow()
+                )
+                redis_client.setex(
+                    f"blacklist:{token}", int(expiry_time.total_seconds()), "revoked"
+                )
+            return {"message": "Logout successful"}
+        except JWTError:
+            raise HTTPException(status_code=401, detail="Invalid token")


### PR DESCRIPTION
This PR introduces the logout functionality by blacklisting JWT tokens using Redis
Router:  
   - Extracts the JWT token using JWTBearer()  
  - Calls the logout method to blacklist the token.  

Service: 
  - Decodes the JWT token to retrieve the expiration timestamp.  
  - Stores the token in Redis with an expiry time matching the token’s remaining lifespan.  
  - Ensures that revoked tokens cannot be used for authentication.  

 Redis Integration:  
  - Redis is used to store blacklisted tokens with a `setex` command.  
  - Tokens are automatically removed from Redis upon expiration.  
  - Before processing any request, `JWTBearer` checks if the token is in Redis and denies access if found.  

 JWT Authentication (`JWTBearer`)**   
  - Before verifying a token, it checks Redis for blacklisted tokens.  
  - If a token is blacklisted, it raises a `401 Unauthorized` error.  




