### PR TITLE
Added 3.2-settleup API

### DIFF
--- a/src/app/repositories/settlements_repository.py
+++ b/src/app/repositories/settlements_repository.py
@@ -1,8 +1,10 @@
 from typing import List, Optional
 from uuid import UUID
+
 from sqlalchemy import desc
+
 from src.app.models.data_models import Settlements
-from repositories.base_repository import BaseRepository
+from src.app.repositories.base_repository import BaseRepository
 
 
 class SettlementRepository(BaseRepository[Settlements]):

--- a/src/app/routes/v1/settlements_routers.py
+++ b/src/app/routes/v1/settlements_routers.py
@@ -1,8 +1,19 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 
-router = APIRouter(tags=["Settlements Routes"])
+from src.app.schemas.settleup_schemas import SettleUpRequest, SettleUpResponse
+from src.app.services.settleup_services import settle_up_service
+from src.app.services.unit_of_work import SettleUpUnitOfWork
+
+router = APIRouter()
 
 
-@router.get("/settle-up/test")
-def testing():
-    return {"message": "Hello World from settle-up!"}
+@router.patch("/settle-up", response_model=SettleUpResponse)
+def settle_up(
+    request: SettleUpRequest,
+):
+    """
+    API endpoint to settle up a transaction.
+    """
+    unit_of_work = SettleUpUnitOfWork()
+    response = settle_up_service(unit_of_work, request.dict())
+    return response

--- a/src/app/schemas/settleup_schemas.py
+++ b/src/app/schemas/settleup_schemas.py
@@ -1,0 +1,38 @@
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PaymentMethod(str, Enum):
+    """
+    Enum for valid payment methods.
+    """
+
+    UPI = "UPI"
+    CASH = "Cash"
+    CARD = "Card"
+    BANK_TRANSFER = "Bank Transfer"
+
+
+class SettleUpRequest(BaseModel):
+    """
+    Pydantic model for settle-up request validation.
+    """
+
+    amount: float = Field(gt=0)
+    payer_id: UUID
+    receiver_id: UUID
+    method: PaymentMethod
+
+
+class SettleUpResponse(BaseModel):
+    """
+    Pydantic model for settle-up response.
+    """
+
+    message: str
+    remaining_balance: float
+    payer_id: UUID
+    receiver_id: UUID
+    settled_amount: float

--- a/src/app/services/settleup_services.py
+++ b/src/app/services/settleup_services.py
@@ -1,0 +1,61 @@
+from pydantic import ValidationError
+
+from src.app.schemas.settleup_schemas import SettleUpRequest, SettleUpResponse
+from src.app.services.unit_of_work import SettleUpUnitOfWork
+
+
+def settle_up_service(
+    unit_of_work: SettleUpUnitOfWork, request_data: dict
+) -> SettleUpResponse:
+    """
+    Service function to handle settle-up logic.
+
+    param unit_of_work: Instance of SettleUpUnitOfWork.
+    param request_data: Dictionary containing settle-up request data.
+    return: SettleUpResponse object.
+    """
+    try:
+        request = SettleUpRequest(**request_data)
+
+        with unit_of_work as uow:
+            settlement = uow.settlement_repository.get_all(
+                payer_id=request.payer_id,
+                payee_id=request.receiver_id,
+                is_settled=False,
+            )
+
+            if not settlement:
+                return SettleUpResponse(
+                    message="No unsettled balance found between the payer and receiver.",
+                    remaining_balance=0.0,
+                    payer_id=request.payer_id,
+                    receiver_id=request.receiver_id,
+                    settled_amount=0.0,
+                )
+
+            settlement = settlement[0]
+            if settlement.amount < request.amount:
+                raise ValueError("Amount exceeds the outstanding balance.")
+
+            settlement.amount -= request.amount
+            if settlement.amount == 0:
+                settlement.is_settled = True
+
+            uow.settlement_repository.update(
+                settlement.id,
+                amount=settlement.amount,
+                is_settled=settlement.is_settled,
+            )
+
+            return SettleUpResponse(
+                message="Settlement completed successfully.",
+                remaining_balance=settlement.amount,
+                payer_id=request.payer_id,
+                receiver_id=request.receiver_id,
+                settled_amount=request.amount,
+            )
+
+    except ValidationError as e:
+        raise ValueError(f"Invalid request data: {e}")
+    except Exception as e:
+        raise ValueError(f"Error during settlement: {e}")

--- a/src/app/services/unit_of_work.py
+++ b/src/app/services/unit_of_work.py
@@ -1,6 +1,7 @@
 from abc import ABC
 
 from src.app.config.database import get_db
+from src.app.repositories.settlements_repository import SettlementRepository
 
 
 class BaseUnitOfWork(ABC):
@@ -48,3 +49,14 @@ class BaseUnitOfWork(ABC):
         Roll back the current transaction, reverting uncommitted changes.
         """
         self.session.rollback()
+
+
+class SettleUpUnitOfWork(BaseUnitOfWork):
+    """
+    Unit of Work for handling settle-up operations.
+    """
+
+    def __enter__(self):
+        super().__enter__()
+        self.settlement_repository = SettlementRepository(self.session)
+        return self


### PR DESCRIPTION
Implemented the settle-up service to handle transaction settlements between payer and receiver. This includes:

- Service Logic: Added settle_up_service to process settle-up requests.
- Schemas: Defined SettleUpRequest and SettleUpResponse models for request validation and response formatting.
- Unit of Work: Created SettleUpUnitOfWork for managing database transactions.
- API Endpoint: Added /settle-up endpoint to handle settle-up requests.