### PR TITLE
4.3-edit_group_details: Implements PATCH for updating group details

### DIFF
--- a/src/app/routes/v1/group_management_routers.py
+++ b/src/app/routes/v1/group_management_routers.py
@@ -1,8 +1,46 @@
-from fastapi import APIRouter
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from src.app.schemas.group_schemas import GroupResponse, GroupUpdateRequest
+from src.app.services.group_services import update_group
+from src.app.services.unit_of_work import GroupUnitOfWork
 
 router = APIRouter(tags=["Group Management Routes"])
 
+authorization_header_scheme = HTTPBearer()
 
-@router.get("/groups/test")
-def testing():
-    return {"message": "Hello World from group!"}
+
+@router.patch("/groups/{group_id}", response_model=GroupResponse)
+def update_group_details(
+    group_id: UUID,
+    group_update: GroupUpdateRequest,
+    token: HTTPAuthorizationCredentials = Depends(authorization_header_scheme),
+):
+    """
+    Update the details of a specific group by its unique identifier.
+
+    Parameters:
+
+        group_id (UUID):
+            The unique identifier of the group.
+
+        group_update (GroupUpdateRequest):
+            The request body containing the updated group details.
+
+        token (HTTPAuthorizationCredentials):
+            The authentication token provided in the request header.
+
+    Returns:
+
+        GroupResponse:
+            The response model containing the updated group's details.
+    """
+    unit_of_work = GroupUnitOfWork()
+    return update_group(
+        unit_of_work=unit_of_work,
+        group_id=group_id,
+        group_update=group_update,
+        token=token,
+    )

--- a/src/app/schemas/group_schemas.py
+++ b/src/app/schemas/group_schemas.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import UUID4, BaseModel
+
+
+class TypeEnum(str, Enum):
+    """
+    Enumeration for different types of groups.
+    Attributes:
+        trip: Represents a group related to trips.
+        home: Represents a home-related group.
+        other: Represents any other type of group.
+    """
+
+    trip = "trip"
+    home = "home"
+    other = "other"
+
+
+class GroupResponse(BaseModel):
+    """
+    Pydantic model representing a response for a group.
+
+    Attributes:
+        id (UUID4): Unique identifier for the group.
+        name (str): Name of the group.
+        type (TypeEnum): Type of the group (trip, home, or other).
+        created_by (UUID4): Unique identifier of the user who created the group.
+        created_at (datetime): Timestamp of when the group was created.
+    """
+
+    id: UUID4
+    name: str
+    type: TypeEnum
+    created_by: UUID4
+    created_at: datetime
+
+    class Config:
+        """Configuration settings for Pydantic model."""
+
+        from_attributes = True
+
+
+class GroupUpdateRequest(BaseModel):
+    """
+    Represents the request payload for updating a group's details.
+
+    Attributes:
+        name (Optional[str]):
+            The new name of the group. Defaults to None if not provided.
+        type (Optional[TypeEnum]):
+            The updated type/category of the group. Defaults to None if not provided.
+        created_by (Optional[UUID4]):
+            The UUID of the user who originally created the group. Defaults to None if not provided.
+    """
+
+    name: Optional[str] = None
+    type: Optional[TypeEnum] = None
+    created_by: Optional[UUID4] = None

--- a/src/app/services/group_services.py
+++ b/src/app/services/group_services.py
@@ -1,0 +1,95 @@
+from uuid import UUID
+
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import JWTError, jwt
+
+from src.app.config.settings import app_config
+from src.app.schemas.group_schemas import GroupResponse, GroupUpdateRequest
+from src.app.services.unit_of_work import GroupUnitOfWork
+
+
+def decode_jwt(token: HTTPAuthorizationCredentials) -> UUID:
+    """
+    Decodes a JWT token and extracts the user ID.
+    Parameters:
+        token (HTTPAuthorizationCredentials):
+            The JWT token extracted from the request header.
+    Returns:
+        UUID:
+            The extracted user ID from the decoded token.
+    Raises:
+        HTTPException:
+            If the token is invalid, expired, or missing the user_id.
+    """
+    try:
+        decoded_payload = jwt.decode(
+            token.credentials,
+            app_config["SECRET_KEY"],
+            algorithms=[app_config["ALGORITHM"]],
+        )
+        user_id = decoded_payload.get("user_id")
+        if not user_id:
+            raise HTTPException(
+                status_code=401, detail="Invalid token: user_id not found"
+            )
+        return UUID(user_id)
+    except JWTError as jwt_error:
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired token"
+        ) from jwt_error
+
+
+def update_group(
+    unit_of_work: GroupUnitOfWork,
+    group_id: UUID,
+    group_update: GroupUpdateRequest,
+    token: HTTPAuthorizationCredentials,
+) -> GroupResponse:
+    """
+    Update the details of a specific group by its unique identifier.
+
+    Parameters:
+        unit_of_work (GroupUnitOfWork):
+            The unit of work used for database operations.
+        group_id (UUID):
+            The unique identifier of the group.
+        group_update (GroupUpdateRequest):
+            The request body containing the updated group details.
+        token (HTTPAuthorizationCredentials):
+            The authentication token provided in the request header.
+
+    Returns:
+        GroupResponse:
+            The response model containing the updated group's details.
+
+    Raises:
+        HTTPException:
+            If the group is not found or if the user is not authorized to update the group.
+    """
+    with unit_of_work as uow:
+        group = uow.group.get(id=group_id)
+        if not group:
+            raise HTTPException(status_code=404, detail="Group not found")
+
+        user_id_from_token = decode_jwt(token)
+
+        # Verify if the user is an admin
+        if group.created_by != user_id_from_token:
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to update the group, User is not admin",
+            )
+
+        # To update only non-None fields
+        update_data = {
+            key: value
+            for key, value in group_update.model_dump().items()
+            if value is not None
+        }
+        if update_data:
+            uow.group.update(id=group_id, **update_data)
+
+        group = uow.group.get(id=group_id)
+        updated_group_details = GroupResponse.model_validate(group)
+    return updated_group_details

--- a/src/app/services/unit_of_work.py
+++ b/src/app/services/unit_of_work.py
@@ -1,6 +1,8 @@
 from abc import ABC
 
 from src.app.config.database import get_db
+from src.app.repositories.group_repository import GroupRepository
+from src.app.repositories.group_user_repository import GroupUserRepository
 
 
 class BaseUnitOfWork(ABC):
@@ -48,3 +50,18 @@ class BaseUnitOfWork(ABC):
         Roll back the current transaction, reverting uncommitted changes.
         """
         self.session.rollback()
+
+
+class GroupUnitOfWork(BaseUnitOfWork):
+    """
+    A Unit of Work implementation for managing database transactions related to groups.
+    """
+
+    def __enter__(self):
+        """
+        Enter the runtime context, initializing a new database session and repositories.
+        """
+        super().__enter__()
+        self.group = GroupRepository(session=self.session)
+        self.group_user = GroupUserRepository(session=self.session)
+        return self


### PR DESCRIPTION
This PR introduces support for partial updates of group details using the PATCH method. The implementation ensures only provided fields are updated while keeping the existing values intact.

**Key Changes:**

1. Added update_group_details endpoint in group_management_routers.py to handle PATCH requests.
2. Introduced GroupUpdateRequest schema to allow partial updates with optional fields.
3. Implemented update_group function in group_services.py that:
    - Decodes the JWT token to validate user authorization.
    - Checks if the user is an admin before allowing updates.
    - Filter out None values before updating the database.
4. Added GroupUnitOfWork in unit_of_work.py to manage transactions for group updates.

**How It Works:**

1. A PATCH request is made to /groups/{group_id} with a payload containing only the fields that need to be updated.
2. The request is validated against the GroupUpdateRequest schema.
3. The JWT token is decoded to verify authorization.
4. The update logic ensures only non-None fields are modified in the database.
5. The updated group details are returned as a response.