### PR TITLE
4.4-view_expenses_in_a_particular_group: Implement API to retrieve all expenses for a specific group

### DIFF
--- a/src/app/routes/v1/group_management_routers.py
+++ b/src/app/routes/v1/group_management_routers.py
@@ -1,8 +1,47 @@
-from fastapi import APIRouter
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from src.app.schemas.expense_schemas import ExpenseResponse
+from src.app.services.group_services import get_expense_from_group
+from src.app.services.unit_of_work import GroupUnitOfWork
 
 router = APIRouter(tags=["Group Management Routes"])
 
+authorization_header_scheme = HTTPBearer()
 
-@router.get("/groups/test")
-def testing():
-    return {"message": "Hello World from group!"}
+
+@router.get("/groups/{group_id}/expenses", response_model=List[ExpenseResponse])
+def get_group_expenses(
+    group_id: UUID,
+    token: HTTPAuthorizationCredentials = Depends(authorization_header_scheme),
+):
+    """
+    Retrieve all expenses associated with a specific group.
+
+    Args:
+
+        group_id (UUID):
+            The unique identifier of the group.
+
+        token (HTTPAuthorizationCredentials):
+            The JWT authorization token extracted from the request header.
+
+    Returns:
+
+        List[ExpenseResponse]:
+            A list of expenses belonging to the specified group.
+
+    Raises:
+
+        HTTPException:
+            If the user is unauthorized or the group does not exist.
+    """
+    unit_of_work = GroupUnitOfWork()
+    return get_expense_from_group(
+        unit_of_work=unit_of_work,
+        group_id=group_id,
+        token=token,
+    )

--- a/src/app/schemas/expense_schemas.py
+++ b/src/app/schemas/expense_schemas.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ExpenseType(str, Enum):
+    """Enum for expense types matching the database."""
+
+    GROUP = "GROUP"
+    NON_EXPENSE_GROUP = "NON-EXPENSE GROUP"
+
+
+class ExpenseResponse(BaseModel):
+    """Schema for viewing an expense."""
+
+    id: UUID
+    group_id: Optional[UUID]
+    total_amount: Decimal
+    description: Optional[str]
+    paid_by: UUID
+    created_at: datetime
+    expense_type: ExpenseType
+
+    class Config:
+        """Configuration settings for Pydantic model."""
+
+        form_attribute = True

--- a/src/app/services/group_services.py
+++ b/src/app/services/group_services.py
@@ -1,0 +1,117 @@
+from typing import List
+from uuid import UUID
+
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import JWTError, jwt
+
+from src.app.config.settings import app_config
+from src.app.schemas.expense_schemas import ExpenseResponse
+from src.app.services.unit_of_work import GroupUnitOfWork
+
+
+def decode_jwt(token: HTTPAuthorizationCredentials) -> UUID:
+    """
+    Decodes a JWT token and extracts the user ID.
+    Parameters:
+        token (HTTPAuthorizationCredentials):
+            The JWT token extracted from the request header.
+    Returns:
+        UUID:
+            The extracted user ID from the decoded token.
+    Raises:
+        HTTPException:
+            If the token is invalid, expired, or missing the user_id.
+    """
+    try:
+        decoded_payload = jwt.decode(
+            token.credentials,
+            app_config["SECRET_KEY"],
+            algorithms=[app_config["ALGORITHM"]],
+        )
+        user_id = decoded_payload.get("user_id")
+        if not user_id:
+            raise HTTPException(
+                status_code=401, detail="Invalid token: user_id not found"
+            )
+        return UUID(user_id)
+    except JWTError as jwt_error:
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired token"
+        ) from jwt_error
+
+
+def get_expense_from_group(
+    unit_of_work: GroupUnitOfWork,
+    group_id: UUID,
+    token: HTTPAuthorizationCredentials,
+) -> List[ExpenseResponse]:
+    """
+    Retrieves all expenses for a given group.
+
+    Args:
+        unit_of_work (GroupUnitOfWork):
+            The unit of work to manage database transactions.
+
+        group_id (UUID):
+            The unique identifier of the group.
+
+        token (HTTPAuthorizationCredentials):
+            The JWT authorization token used to authenticate the request.
+
+    Returns:
+        List[ExpenseResponse]:
+            A list of expenses associated with the specified group.
+
+    Raises:
+        HTTPException (403):
+            If the user is not a member of the specified group.
+
+        HTTPException (404):
+            If no expenses are found for the given group.
+    """
+    with unit_of_work as uow:
+        user_id_from_token = decode_jwt(token)
+        if not is_group_member(group_id, user_id_from_token, uow):
+            raise HTTPException(
+                status_code=403, detail="User is not a member of the group"
+            )
+
+        expense_list = uow.expense.get_all(group_id=group_id)
+        if expense_list:
+            group_expense_list = [
+                ExpenseResponse.model_validate(expense.__dict__)
+                for expense in expense_list
+            ]
+        else:
+            group_expense_list = []  # return an empty list if no expenses are found
+
+    return group_expense_list
+
+
+def is_group_member(
+    group_id: UUID,
+    user_id: UUID,
+    unit_of_work: GroupUnitOfWork,
+) -> bool:
+    """
+    Checks if a user is a member of the specified group.
+    Parameters:
+        group_id (UUID):
+            The unique identifier of the group.
+        user_id (UUID):
+            The unique identifier of the user.
+    Returns:
+        bool:
+            True if the user is a member of the group, False otherwise.
+    """
+    with unit_of_work as uow:
+        group = uow.group.get(id=group_id)
+        if not group:
+            raise HTTPException(status_code=404, detail="Group not found")
+        if group.created_by == user_id:
+            return True
+        group_user = uow.group_user.get_all(group_id=group_id, user_id=user_id)
+        if group_user:
+            return True
+        return False

--- a/src/app/services/unit_of_work.py
+++ b/src/app/services/unit_of_work.py
@@ -1,6 +1,9 @@
 from abc import ABC
 
 from src.app.config.database import get_db
+from src.app.repositories.expense_repository import ExpenseRepository
+from src.app.repositories.group_repository import GroupRepository
+from src.app.repositories.group_user_repository import GroupUserRepository
 
 
 class BaseUnitOfWork(ABC):
@@ -48,3 +51,19 @@ class BaseUnitOfWork(ABC):
         Roll back the current transaction, reverting uncommitted changes.
         """
         self.session.rollback()
+
+
+class GroupUnitOfWork(BaseUnitOfWork):
+    """
+    A Unit of Work implementation for managing database transactions related to groups.
+    """
+
+    def __enter__(self):
+        """
+        Enter the runtime context, initializing a new database session and repositories.
+        """
+        super().__enter__()
+        self.group = GroupRepository(session=self.session)
+        self.group_user = GroupUserRepository(session=self.session)
+        self.expense = ExpenseRepository(session=self.session)
+        return self


### PR DESCRIPTION
This PR introduces the `GET /groups/{group_id}/expenses` endpoint to fetch all expenses associated with a given group.

- Added JWT-based authentication to validate users before retrieving expenses.
- Returns details such as:
    - `id` (Expense ID)
    - `group_id` (Group ID)
    - `total_amount` (Total expense amount)
    - `description` (Expense description)
    - `paid_by` (User who paid)
    - `created_at` (Timestamp of creation)
    - `expense_type` (Type of expense)
- Ensures only group members can access the expenses.
- Returns a empty list if no expenses are found.