### PR TITLE
4.5-view_group_members: API to retrieve list of members in a specific group

### DIFF
--- a/src/app/routes/v1/group_management_routers.py
+++ b/src/app/routes/v1/group_management_routers.py
@@ -1,8 +1,47 @@
-from fastapi import APIRouter
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from src.app.schemas.group_schemas import GroupMemberResponse
+from src.app.services.group_services import get_group_members
+from src.app.services.unit_of_work import GroupUnitOfWork
 
 router = APIRouter(tags=["Group Management Routes"])
 
+authorization_header_scheme = HTTPBearer()
 
-@router.get("/groups/test")
-def testing():
-    return {"message": "Hello World from group!"}
+
+@router.get("/groups/{group_id}/members", response_model=List[GroupMemberResponse])
+def list_group_members(
+    group_id: UUID,
+    token: HTTPAuthorizationCredentials = Depends(authorization_header_scheme),
+):
+    """
+    API endpoint to retrieve the list of members in a specified group.
+
+    Args:
+
+        group_id (UUID):
+            The unique identifier of the group.
+
+        token (HTTPAuthorizationCredentials):
+            The authentication token extracted from the request header.
+
+    Returns:
+
+        List[GroupMemberResponse]:
+            A list of group members with their details.
+
+    Raises:
+
+        HTTPException:
+            If the requesting user is not authorized to view the group members.
+    """
+    unit_of_work = GroupUnitOfWork()
+    return get_group_members(
+        unit_of_work=unit_of_work,
+        group_id=group_id,
+        token=token,
+    )

--- a/src/app/schemas/group_schemas.py
+++ b/src/app/schemas/group_schemas.py
@@ -1,0 +1,25 @@
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class GroupMemberResponse(BaseModel):
+    """
+    Represents a response model for a group member.
+
+    Attributes:
+        id (UUID): The unique identifier of the group member.
+        name (str): The name of the group member.
+        email (EmailStr): The email address of the group member.
+        profile_picture_url (str): The URL of the group member's profile picture.
+    """
+
+    id: UUID
+    name: str
+    email: EmailStr
+    profile_picture_url: str
+
+    class Config:
+        """Configuration settings for Pydantic model."""
+
+        form_attribute = True

--- a/src/app/services/group_services.py
+++ b/src/app/services/group_services.py
@@ -1,0 +1,117 @@
+from typing import List
+from uuid import UUID
+
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import JWTError, jwt
+
+from src.app.config.settings import app_config
+from src.app.schemas.group_schemas import GroupMemberResponse
+from src.app.services.unit_of_work import GroupUnitOfWork
+
+
+def decode_jwt(token: HTTPAuthorizationCredentials) -> UUID:
+    """
+    Decodes a JWT token and extracts the user ID.
+
+    Parameters:
+        token (HTTPAuthorizationCredentials):
+            The JWT token extracted from the request header.
+
+    Returns:
+        UUID:
+            The extracted user ID from the decoded token.
+
+    Raises:
+        HTTPException:
+            If the token is invalid, expired, or missing the user_id.
+    """
+    try:
+        decoded_payload = jwt.decode(
+            token.credentials,
+            app_config["SECRET_KEY"],
+            algorithms=[app_config["ALGORITHM"]],
+        )
+        user_id = decoded_payload.get("user_id")
+        if not user_id:
+            raise HTTPException(
+                status_code=401, detail="Invalid token: user_id not found"
+            )
+        return UUID(user_id)
+    except JWTError as jwt_error:
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired token"
+        ) from jwt_error
+
+
+def is_group_member(
+    group_id: UUID,
+    user_id: UUID,
+    unit_of_work: GroupUnitOfWork,
+) -> bool:
+    """
+    Checks if a user is a member of the specified group.
+
+    Parameters:
+        group_id (UUID):
+            The unique identifier of the group.
+        user_id (UUID):
+            The unique identifier of the user.
+        unit_of_work (GroupUnitOfWork):
+            The unit of work instance to handle database operations.
+
+    Returns:
+        bool:
+            True if the user is a member of the group, False otherwise.
+    """
+    with unit_of_work as uow:
+        group = uow.group.get(id=group_id)
+        if not group:
+            raise HTTPException(status_code=404, detail="Group not found")
+        if group.created_by == user_id:
+            return True
+        group_user = uow.group_user.get_all(group_id=group_id, user_id=user_id)
+        if group_user:
+            return True
+        return False
+
+
+def get_group_members(
+    unit_of_work: GroupUnitOfWork,
+    group_id: UUID,
+    token: HTTPAuthorizationCredentials,
+) -> List[GroupMemberResponse]:
+    """
+    Retrieves the list of members in a specified group.
+
+    Args:
+        unit_of_work (GroupUnitOfWork):
+            The unit of work instance to handle database operations.
+        group_id (UUID):
+            The unique identifier of the group.
+        token (HTTPAuthorizationCredentials):
+            The authentication token of the requesting user.
+
+    Returns:
+        List[GroupMemberResponse]:
+            A list of group members with their details.
+
+    Raises:
+        HTTPException:
+            If the requesting user is not a member of the specified group.
+    """
+    with unit_of_work as uow:
+        user_id_from_token = decode_jwt(token)
+        if not is_group_member(group_id, user_id_from_token, uow):
+            raise HTTPException(
+                status_code=403, detail="User is not a member of the group"
+            )
+
+        user_list = []
+        users = uow.group_user.get_all(group_id=group_id)
+
+        for user in users:
+            user_details = uow.user.get(user.user_id)
+            user_list.append(GroupMemberResponse.model_validate(user_details.__dict__))
+
+    return user_list

--- a/src/app/services/unit_of_work.py
+++ b/src/app/services/unit_of_work.py
@@ -1,6 +1,9 @@
 from abc import ABC
 
 from src.app.config.database import get_db
+from src.app.repositories.group_repository import GroupRepository
+from src.app.repositories.group_user_repository import GroupUserRepository
+from src.app.repositories.user_repository import UserRepository
 
 
 class BaseUnitOfWork(ABC):
@@ -48,3 +51,19 @@ class BaseUnitOfWork(ABC):
         Roll back the current transaction, reverting uncommitted changes.
         """
         self.session.rollback()
+
+
+class GroupUnitOfWork(BaseUnitOfWork):
+    """
+    A Unit of Work implementation for managing database transactions related to groups.
+    """
+
+    def __enter__(self):
+        """
+        Enter the runtime context, initializing a new database session and repositories.
+        """
+        super().__enter__()
+        self.user = UserRepository(session=self.session)
+        self.group = GroupRepository(session=self.session)
+        self.group_user = GroupUserRepository(session=self.session)
+        return self


### PR DESCRIPTION
Added an API endpoint `GET /groups/{group_id}/members` to retrieve members of a specified group. Implemented authentication via JWT, verified group membership, and ensured only authorized users could access member details.

- Returns a list of group members, including their ID, name, email, and profile picture.
- Ensures only authorized users can access group members.
- Decodes JWT tokens to authenticate users and verifies group membership.
- Raises HTTPException for unauthorized access or invalid tokens.
- Added GroupMemberResponse schema for structured API responses.
- Introduced GroupUnitOfWork to manage database transactions efficiently.